### PR TITLE
Added provisioners relation to state file

### DIFF
--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -314,6 +314,13 @@ resource "aws_instance" "web" {
 }
 ```
 
+## Terraform state for provisioners
+
+Because provisioners are designed to run only once - during creation or deletion of the resource, and
+they can introduce potentially any changes they want to resource, terraform does not store any information
+about provisioners in its state. The nature of the changes and the way to update these changes is unknown
+to terraform, therefore, tracking it in the state does not make much sense.
+
 ## Failure Behavior
 
 By default, provisioners that fail will also cause the Terraform apply


### PR DESCRIPTION
Current documentation does not state that provisioners are not saved in state file. I've added the doc about it along with motivation.